### PR TITLE
Reduce crate size considerably using 'include' directive in manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/hlmtre/homemaker"
 keywords = ["dotfiles", "management", "dotfile"]
 categories = ["command-line-utilities", "filesystem"]
+include = ["src/**/*", "LICENSE", "README.md"]
 
 [lib]
 name = "hm"


### PR DESCRIPTION
Please let me know if there is anything else that should be included
and I am happy to make the fix.

```
➜  homemaker git:(master) cargo diet
┌────────────────────────────┬─────────────┐
│ Removed File               │ Size (Byte) │
├────────────────────────────┼─────────────┤
│ rustfmt.toml               │          14 │
│ .gitignore                 │          23 │
│ .whitesource               │         213 │
│ .github/workflows/rust.yml │         316 │
│ benches/config.toml        │         424 │
│ benches/benchy_bench.rs    │         545 │
│ doc/dep_graph.png          │       26587 │
│ doc/hm.webm                │      490111 │
│ doc/hm.gif                 │     2281478 │
└────────────────────────────┴─────────────┘
Saved 99% or 2.8 MB in 9 files (of 2.8 MB and 18 files in entire crate)
```